### PR TITLE
17728 refresh token fails causing 401 error

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -24,7 +24,7 @@ function handleRequestWithRetry(requestFn, options, callbackData, callbacks) {
             sys.logs.info("[zoho] Handling request...: "+ JSON.stringify(error));
             const accessTokenResponse = httpService.post({url: config.get("ZOHO_OAUTH_API_BASE_URL")+"/oauth/v2/token?refresh_token=" + sys.storage.get('installationInfo-Zoho-User-'+sys.context.getCurrentUserRecord().id() + ' - refresh_token', {decrypt:true}) + "&client_id=" + config.get().clientId + "&client_secret=" + config.get().clientSecret + "&redirect_uri=" + config.get().oauthCallback + "&grant_type=refresh_token"});
             if (!!accessTokenResponse && !!accessTokenResponse.access_token) {
-                sys.storage.put(config.get().id + ' - access_token', accessTokenResponse.access_token, {encrypt: true});
+                sys.storage.put('installationInfo-Zoho-User-'+sys.context.getCurrentUserRecord().id() + ' - access_token', accessTokenResponse.access_token, {encrypt: true});
             }
             return requestFn(setAuthorization(options), callbackData, callbacks);
         } else {

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -22,7 +22,7 @@ function handleRequestWithRetry(requestFn, options, callbackData, callbacks) {
     } catch (error) {
         if (error.additionalInfo.status === 401) {
             sys.logs.info("[zoho] Handling request...: "+ JSON.stringify(error));
-            dependencies.oauth.functions.refreshToken('zoho:refreshToken');
+            httpService.post({url: config.get("ZOHO_OAUTH_API_BASE_URL")+"/oauth/v2/token?refresh_token=" + sys.storage.get('installationInfo-Zoho-User-'+sys.context.getCurrentUserRecord().id() + ' - refresh_token', {decrypt:true})});
             return requestFn(setAuthorization(options), callbackData, callbacks);
         } else {
             throw error;

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -22,7 +22,7 @@ function handleRequestWithRetry(requestFn, options, callbackData, callbacks) {
     } catch (error) {
         if (error.additionalInfo.status === 401) {
             sys.logs.info("[zoho] Handling request...: "+ JSON.stringify(error));
-            const accessTokenResponse = httpService.post({url: config.get("ZOHO_OAUTH_API_BASE_URL")+"/oauth/v2/token?refresh_token=" + sys.storage.get('installationInfo-Zoho-User-'+sys.context.getCurrentUserRecord().id() + ' - refresh_token', {decrypt:true})});
+            const accessTokenResponse = httpService.post({url: config.get("ZOHO_OAUTH_API_BASE_URL")+"/oauth/v2/token?refresh_token=" + sys.storage.get('installationInfo-Zoho-User-'+sys.context.getCurrentUserRecord().id() + ' - refresh_token', {decrypt:true}) + "&client_id=" + config.get().clientId + "&client_secret=" + config.get().clientSecret + "&redirect_uri=" + config.get().oauthCallback + "&grant_type=refresh_token"});
             if (!!accessTokenResponse && !!accessTokenResponse.access_token) {
                 sys.storage.put(config.get().id + ' - access_token', accessTokenResponse.access_token, {encrypt: true});
             }

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -22,7 +22,9 @@ function handleRequestWithRetry(requestFn, options, callbackData, callbacks) {
     } catch (error) {
         if (error.additionalInfo.status === 401) {
             sys.logs.info("[zoho] Handling request...: "+ JSON.stringify(error));
-            const accessTokenResponse = httpService.post({url: config.get("ZOHO_OAUTH_API_BASE_URL")+"/oauth/v2/token?refresh_token=" + sys.storage.get('installationInfo-Zoho-User-'+sys.context.getCurrentUserRecord().id() + ' - refresh_token', {decrypt:true}) + "&client_id=" + config.get().clientId + "&client_secret=" + config.get().clientSecret + "&redirect_uri=" + config.get().oauthCallback + "&grant_type=refresh_token"});
+            const actualRefreshToken = sys.storage.get('installationInfo-Zoho-User-'+sys.context.getCurrentUserRecord().id() + ' - refresh_token', {decrypt:true});
+            const url = config.get("ZOHO_OAUTH_API_BASE_URL")+"/oauth/v2/token?refresh_token=" + actualRefreshToken + "&client_id=" + config.get("clientId") + "&client_secret=" + config.get("clientSecret") + "&redirect_uri=" + config.get("oauthCallback") + "&grant_type=refresh_token";
+            const accessTokenResponse = httpService.post({url: url});
             if (!!accessTokenResponse && !!accessTokenResponse.access_token) {
                 sys.storage.put('installationInfo-Zoho-User-'+sys.context.getCurrentUserRecord().id() + ' - access_token', accessTokenResponse.access_token, {encrypt: true});
             }

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -22,7 +22,10 @@ function handleRequestWithRetry(requestFn, options, callbackData, callbacks) {
     } catch (error) {
         if (error.additionalInfo.status === 401) {
             sys.logs.info("[zoho] Handling request...: "+ JSON.stringify(error));
-            httpService.post({url: config.get("ZOHO_OAUTH_API_BASE_URL")+"/oauth/v2/token?refresh_token=" + sys.storage.get('installationInfo-Zoho-User-'+sys.context.getCurrentUserRecord().id() + ' - refresh_token', {decrypt:true})});
+            const accessTokenResponse = httpService.post({url: config.get("ZOHO_OAUTH_API_BASE_URL")+"/oauth/v2/token?refresh_token=" + sys.storage.get('installationInfo-Zoho-User-'+sys.context.getCurrentUserRecord().id() + ' - refresh_token', {decrypt:true})});
+            if (!!accessTokenResponse && !!accessTokenResponse.access_token) {
+                sys.storage.put(config.get().id + ' - access_token', accessTokenResponse.access_token, {encrypt: true});
+            }
             return requestFn(setAuthorization(options), callbackData, callbacks);
         } else {
             throw error;


### PR DESCRIPTION
## What it does?
Fixes bug
## How to test it?
You can try on https://testing457rc.tarzan.io/dev/ I've already created a zoho package installation with the latest version, you
can navigate to Books grid view, then click on More and execute the Test Zoho action, once executed you can review the access_token and refresh_token keys within the monitor in the storage section, make sure both keys have been set. Afterwards we'll remove the access_token in order to simulate an unauthorized error, set the access_token value to empty, finally execute the following code:

```
let response;
response = pkg.zoho.api.get('/users/me');
log(JSON.stringify(response));
```
You should receive a valid response, look at the logs and make sure it failed in the first attempt, then make sure it tried to get a new access_token.

Execute the scripts from the readme.
[Checklist for packages](https://docs.google.com/document/d/1rMDvwVnbCTNuC0Z8z3An3c5UpnvY4S2CUEuJMoLsAAg/edit#heading=h.tn1fsa44no8t)
Remember to use this [checklist](https://docs.google.com/document/d/139rKhIsvpT3yBSB88BBZfy03fD_Sried0bVwIWVaHJk/edit?usp=sharing) for the review.
## Technical notes
There are no technical notes.
## Deployment notes
There are no deployment notes.