### PR TITLE
Allow use only one account

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ are known to both Zoho and your application. Do not share this credentials anywh
 **Type**: text
 **Mandatory**: false
 
+#### OAuth Account ID
+
+**Name**: oauthAccountId
+**Type**: text
+**Mandatory**: false
+
 # Javascript API
 
 ## HTTP requests

--- a/configurationBuilder.js
+++ b/configurationBuilder.js
@@ -7,7 +7,7 @@
 
 let configurationBuilder = function (config) {
     config.oauth = {
-        id: 'installationInfo-Zoho-User-'+sys.context.getCurrentUserRecord().id(),
+        id: config.oauthAccountId || 'installationInfo-Zoho-User-'+sys.context.getCurrentUserRecord().id(),
         authUrl: config.ZOHO_OAUTH_API_BASE_URL + "/oauth/v2/auth",
         accessTokenUrl: config.ZOHO_OAUTH_API_BASE_URL + "/oauth/v2/token",
         clientId: config.clientId,

--- a/package.json
+++ b/package.json
@@ -71,6 +71,11 @@
             "required": false
         },
         {
+            "name": "oauthAccountId",
+            "label": "OAuth Account ID",
+            "type": "text"
+        },
+        {
             "name": "oauthCallback",
             "label": "OAuth callback",
             "description": "The OAuth callback to configure in your Zoho App",


### PR DESCRIPTION
Pull-request for issue https://github.com/slingr-stack/platform/issues/17840 created by @pasaperez-slingr

## What it does?

Adds the possibility of overwriting the id where the tokens will be saved in the storage.

## How to test it?

Configure in the dynamic configuration script of this package:

```js
  config.id = "customCredentialsZoho";
  return config;
```

Remember to use this [checklist](https://docs.google.com/document/d/139rKhIsvpT3yBSB88BBZfy03fD_Sried0bVwIWVaHJk/edit?usp=sharing) for the review.

## Technical notes

There are no technical notes.

## Deployment notes

Update the package to v1.1.0 version from app-builder.